### PR TITLE
fix: convert dueDate to Date object when loading from localStorage

### DIFF
--- a/lib/kanban.ts
+++ b/lib/kanban.ts
@@ -43,6 +43,7 @@ export function loadTasks(): Task[] {
       ...task,
       priority: task.priority || 'medium', // Default priority for existing tasks
       createdAt: new Date(task.createdAt),
+      dueDate: task.dueDate ? new Date(task.dueDate) : undefined,
     }));
   } catch {
     return [];


### PR DESCRIPTION
Fixed critical bug where dueDate was stored as ISO string in localStorage but not converted back to Date object on load. This caused all date comparison functions (isOverdue, isDueSoon) and formatting to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)